### PR TITLE
Add Metaractor::Organizer

### DIFF
--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -12,6 +12,7 @@ require "metaractor/context_has_key"
 require "metaractor/failure_output"
 require "i18n"
 require "metaractor/namespace"
+require "metaractor/organizer"
 
 module Metaractor
   def self.included(base)

--- a/lib/metaractor/organizer.rb
+++ b/lib/metaractor/organizer.rb
@@ -1,0 +1,10 @@
+module Metaractor
+  module Organizer
+    def self.included(base)
+      base.class_eval do
+        include Metaractor
+        include Interactor::Organizer
+      end
+    end
+  end
+end


### PR DESCRIPTION
I got tired of writing:

```ruby
include Metaractor
include Interactor::Organizer
```

Now I can write:

```ruby
include Metaractor::Organizer
```